### PR TITLE
fix: handle auth session manually

### DIFF
--- a/src/common/components/information-actions.desktop.tsx
+++ b/src/common/components/information-actions.desktop.tsx
@@ -13,8 +13,9 @@ import {
 	IconQuestionMark,
 	IconSettings,
 } from "@tabler/icons-react";
-import { useNavigate } from "@tanstack/react-router";
 import { lazy, Suspense } from "react";
+
+import { NavButton } from "./nav-button";
 
 const BeerLocationSubmissionDialog = lazy(
 	() => import("@feature/submissions/create-beer-location-submission.dialog"),
@@ -24,7 +25,6 @@ const InformationActionsDesktop = () => {
 	const [modalOpened, { open, close }] = useDisclosure(false);
 	const [beerSubmissionDialogOpen, beerSubmissionDialogActions] =
 		useDisclosure(false);
-	const navigate = useNavigate();
 
 	return (
 		<>
@@ -61,15 +61,9 @@ const InformationActionsDesktop = () => {
 					>
 						Föreslå ny plats
 					</Button>
-					<Button
-						onClick={() => {
-							navigate({ to: "/admin/view-beer-locations" });
-							close();
-						}}
-						leftSection={<IconSettings />}
-					>
+					<NavButton to="/admin" leftSection={<IconSettings />}>
 						Administrera
-					</Button>
+					</NavButton>
 					<Button
 						component="a"
 						href="https://github.com/jesperorb/billig-bir"

--- a/src/common/components/information-actions.mobile.tsx
+++ b/src/common/components/information-actions.mobile.tsx
@@ -6,8 +6,9 @@ import {
 	IconExternalLink,
 	IconSettings,
 } from "@tabler/icons-react";
-import { useNavigate } from "@tanstack/react-router";
 import { lazy, Suspense } from "react";
+
+import { NavButton } from "./nav-button";
 
 const BeerLocationSubmissionDialog = lazy(
 	() => import("@feature/submissions/create-beer-location-submission.dialog"),
@@ -16,7 +17,6 @@ const BeerLocationSubmissionDialog = lazy(
 const InformationActionsMobile = () => {
 	const [beerSubmissionDialogOpen, beerSubmissionDialogActions] =
 		useDisclosure(false);
-	const navigate = useNavigate();
 
 	return (
 		<Stack gap="md" w="100%">
@@ -44,16 +44,9 @@ const InformationActionsMobile = () => {
 			>
 				Föreslå ny plats
 			</Button>
-			<Button
-				fullWidth
-				onClick={() => {
-					navigate({ to: "/admin/view-beer-locations" });
-					close();
-				}}
-				leftSection={<IconSettings />}
-			>
+			<NavButton fullWidth to="/admin" leftSection={<IconSettings />}>
 				Administrera
-			</Button>
+			</NavButton>
 			<Button
 				fullWidth
 				component="a"

--- a/src/feature/admin/index.tsx
+++ b/src/feature/admin/index.tsx
@@ -1,13 +1,37 @@
-import { Outlet } from "@tanstack/react-router";
+import { LoadingOverlay } from "@mantine/core";
+import { Outlet, useNavigate } from "@tanstack/react-router";
+import { useEffect } from "react";
+
+import ApiClientWrapper from "@common/api/api-client-wrapper";
+import { useSession } from "@common/api/use-session";
+import Layout from "@common/components/layout";
 
 import { AdminNavigation } from "./navigation";
 
 const AdminPage = () => {
+	const session = useSession();
+	const navigate = useNavigate();
+	useEffect(() => {
+		if (!session.data && !session.isLoading) {
+			navigate({ to: "/login" });
+		}
+	}, [navigate, session]);
+	if (session.isLoading || !session.data) {
+		return (
+			<LoadingOverlay
+				visible
+				zIndex={1000}
+				overlayProps={{ radius: "sm", blur: 2 }}
+			/>
+		);
+	}
 	return (
-		<>
-			<AdminNavigation />
-			<Outlet />
-		</>
+		<ApiClientWrapper>
+			<Layout>
+				<AdminNavigation />
+				<Outlet />
+			</Layout>
+		</ApiClientWrapper>
 	);
 };
 

--- a/src/feature/auth/index.tsx
+++ b/src/feature/auth/index.tsx
@@ -32,7 +32,7 @@ const Login = () => {
 	};
 
 	useEffect(() => {
-		if (session?.user) {
+		if (session.data?.user) {
 			navigate({ to: "/admin" });
 		}
 	}, [session, navigate]);

--- a/src/routes/admin.tsx
+++ b/src/routes/admin.tsx
@@ -1,16 +1,7 @@
-import { createFileRoute, Outlet } from "@tanstack/react-router";
+import { createFileRoute } from "@tanstack/react-router";
 
-import ApiClientWrapper from "@common/api/api-client-wrapper";
-import Layout from "@common/components/layout";
-import { AdminNavigation } from "@feature/admin/navigation";
+import AdminPage from "@feature/admin";
 
 export const Route = createFileRoute("/admin")({
-	component: () => (
-		<ApiClientWrapper>
-			<Layout>
-				<AdminNavigation />
-				<Outlet />
-			</Layout>
-		</ApiClientWrapper>
-	),
+	component: AdminPage,
 });

--- a/src/routes/login.tsx
+++ b/src/routes/login.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, redirect } from "@tanstack/react-router";
+import { createFileRoute } from "@tanstack/react-router";
 
 import ApiClientWrapper from "@common/api/api-client-wrapper";
 import Layout from "@common/components/layout";
@@ -12,17 +12,4 @@ export const Route = createFileRoute("/login")({
 			</Layout>
 		</ApiClientWrapper>
 	),
-	beforeLoad: async ({ location }) => {
-		const { getSupabaseClient } = await import("@common/api/api-client");
-		const session = (await getSupabaseClient().auth.getSession()).data.session;
-		if (!session) {
-			// eslint-disable-next-line @typescript-eslint/only-throw-error
-			throw redirect({
-				to: "/login",
-				search: {
-					redirect: location.href,
-				},
-			});
-		}
-	},
 });


### PR DESCRIPTION
- For some reason the onBeforeLoad-function would not redirect at all or being called when implemented on the /admin route. So move functionality to redirect to local component level instead and save session to query client so it can be reused